### PR TITLE
Add simple AddictionRanks leaderboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # AddictionRanks
-A site where addicts can see who the biggest addict is (WIP)
+
+Eine super simple Leaderboard-Webseite mit zwei Kategorien:
+- Alkohol
+- Rauchen
+
+## Features
+- Username + Foto hochladen
+- Kategorie auswählen
+- Upvote / Downvote pro Eintrag
+- Sortierung nach Score
+- Datenspeicherung im Browser (LocalStorage)
+
+## Starten
+Einfach `index.html` im Browser öffnen oder lokal hosten, z. B.:
+
+```bash
+python3 -m http.server 8000
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AddictionRanks</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>AddictionRanks</h1>
+        <p class="subtitle">Ein simples Leaderboard für Alkohol &amp; Rauchen.</p>
+      </header>
+
+      <section class="card">
+        <h2>Eintrag hinzufügen</h2>
+        <form id="entry-form">
+          <label>
+            Username
+            <input type="text" id="username" maxlength="24" required />
+          </label>
+
+          <label>
+            Sucht
+            <select id="addiction" required>
+              <option value="">Bitte wählen</option>
+              <option value="Alkohol">Alkohol</option>
+              <option value="Rauchen">Rauchen</option>
+            </select>
+          </label>
+
+          <label>
+            Foto hochladen
+            <input type="file" id="photo" accept="image/*" required />
+          </label>
+
+          <button type="submit">Eintragen</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Leaderboard</h2>
+        <p class="hint">Upvote = bestätigt echte Addiction. Downvote = eher nicht.</p>
+        <div id="leaderboard" class="leaderboard"></div>
+      </section>
+    </main>
+
+    <template id="entry-template">
+      <article class="entry">
+        <img class="entry-photo" alt="Upload eines Users" />
+        <div class="entry-content">
+          <h3 class="entry-name"></h3>
+          <p class="entry-addiction"></p>
+          <p class="entry-score"></p>
+          <div class="entry-actions">
+            <button class="vote-up" type="button">⬆ Upvote</button>
+            <button class="vote-down" type="button">⬇ Downvote</button>
+          </div>
+        </div>
+      </article>
+    </template>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,98 @@
+const STORAGE_KEY = "addictionranks.entries";
+
+const form = document.querySelector("#entry-form");
+const leaderboard = document.querySelector("#leaderboard");
+const template = document.querySelector("#entry-template");
+
+function loadEntries() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveEntries(entries) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+}
+
+function sortEntries(entries) {
+  return [...entries].sort((a, b) => b.score - a.score);
+}
+
+function render(entries) {
+  leaderboard.innerHTML = "";
+
+  if (entries.length === 0) {
+    leaderboard.innerHTML = '<p class="empty">Noch keine Einträge vorhanden.</p>';
+    return;
+  }
+
+  sortEntries(entries).forEach((entry) => {
+    const node = template.content.firstElementChild.cloneNode(true);
+
+    node.querySelector(".entry-photo").src = entry.photo;
+    node.querySelector(".entry-name").textContent = entry.username;
+    node.querySelector(".entry-addiction").textContent = `Sucht: ${entry.addiction}`;
+    node.querySelector(".entry-score").textContent = `Score: ${entry.score}`;
+
+    node.querySelector(".vote-up").addEventListener("click", () => {
+      updateScore(entry.id, 1);
+    });
+
+    node.querySelector(".vote-down").addEventListener("click", () => {
+      updateScore(entry.id, -1);
+    });
+
+    leaderboard.appendChild(node);
+  });
+}
+
+function updateScore(id, delta) {
+  const entries = loadEntries();
+  const nextEntries = entries.map((entry) =>
+    entry.id === id ? { ...entry, score: entry.score + delta } : entry,
+  );
+  saveEntries(nextEntries);
+  render(nextEntries);
+}
+
+function fileToDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+
+  const username = document.querySelector("#username").value.trim();
+  const addiction = document.querySelector("#addiction").value;
+  const file = document.querySelector("#photo").files[0];
+
+  if (!username || !addiction || !file) return;
+
+  const photo = await fileToDataUrl(file);
+  const entries = loadEntries();
+
+  entries.push({
+    id: crypto.randomUUID(),
+    username,
+    addiction,
+    photo,
+    score: 0,
+  });
+
+  saveEntries(entries);
+  render(entries);
+  form.reset();
+});
+
+render(loadEntries());

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,124 @@
+:root {
+  color-scheme: light;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f4f4f4;
+  color: #111;
+}
+
+.container {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.subtitle {
+  margin-top: 0;
+  color: #555;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+label {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.95rem;
+}
+
+input,
+select,
+button {
+  font: inherit;
+  padding: 0.6rem;
+  border-radius: 8px;
+  border: 1px solid #bbb;
+}
+
+button {
+  cursor: pointer;
+  background: #111;
+  color: #fff;
+  border: 0;
+}
+
+button:hover {
+  opacity: 0.9;
+}
+
+.hint {
+  margin-top: 0;
+  color: #555;
+}
+
+.leaderboard {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.entry {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.entry-photo {
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 8px;
+  background: #eee;
+}
+
+.entry-content h3,
+.entry-content p {
+  margin: 0 0 0.4rem;
+}
+
+.entry-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.entry-actions button {
+  background: #222;
+  padding: 0.45rem 0.6rem;
+}
+
+.empty {
+  margin: 0;
+  color: #666;
+}
+
+@media (max-width: 620px) {
+  .entry {
+    grid-template-columns: 1fr;
+  }
+
+  .entry-photo {
+    width: 100%;
+    height: 220px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal static single-page site to collect and rank self-reported addictions so the community can confirm via votes whether an addiction is "real", with two fixed categories `Alkohol` and `Rauchen`.
- The page should be intentionally simple, accept user-uploaded photos (no AI-generated images), and store data locally so it can be run without a backend.
- Keine der im Agenten-Guide gelisteten Skills wurde verwendet; die Änderung ist eine kleine, eigenständige statische Web-Frontend-Implementierung.

### Description
- Added `index.html`, `styles.css`, and `script.js` to implement a single-page UI with an entry form (username, category, photo) and a leaderboard area.
- Implemented client-side image upload conversion to data URLs and persistence of entries and votes in `localStorage` under the key `addictionranks.entries`.
- Implemented Upvote/Downvote controls that update an entry `score` and a sort routine that renders entries ordered by score.
- Added a brief `README.md` with features and a `python3 -m http.server` quick-start instruction.

### Testing
- Ran `git diff --check` with no reported issues, which completed successfully.
- Started a local static server with `python3 -m http.server 8000` and manually loaded the page for validation, which worked as expected.
- Captured a Playwright screenshot of the running page (`artifacts/addictionranks-home.png`) to verify rendering, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac75002a90832a884858e68157a513)