### PR TITLE
Add client-side AddictionRanks app: leaderboards, forum, profiles, and styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # AddictionRanks
-A site where addicts can see who the biggest addict is (WIP)
+
+Terminal-Style Web-App (schwarzes UI + grüne Schrift) mit Leaderboards, Forum und Profilseiten.
+
+## Kategorien
+### Leaderboard
+- Alkohol
+- Rauchen
+- Screentime
+- Glücksspiel
+
+### Forum
+- Off topic
+- Videospiele
+- Selbsthilfe
+- Selbstzerstörung
+
+## Features
+- Sehr simples Login: nur Code + Name
+- Profilseiten pro User: `profile.html?code=DEINCODE`
+- Profilbilder werden an vielen Stellen angezeigt (Leaderboard, User-Ranking, Forum, Profilübersicht)
+- Forum mit optionalem Bild-Upload pro Beitrag
+- Ein Vote pro User pro Bild
+
+## Starten
+```bash
+cd /workspace/AddictionRanks
+python3 -m http.server 8000
+```
+
+Dann öffnen:
+- `http://localhost:8000`
+- `http://localhost:8000/forum.html`
+- `http://localhost:8000/profile.html`
+
+## Subdomain-Idee (für echte Website)
+Du willst statt `profile.html?code=ABC123` lieber sowas wie:
+- `abc123.deinedomain.com`
+
+Das geht **nicht gut mit rein statischen einzelnen Profil-Dateien** für jeden User.
+Besser ist:
+1. Wildcard-DNS setzen: `*.deinedomain.com` -> Server/IP
+2. Wildcard-TLS-Zertifikat für `*.deinedomain.com`
+3. Webserver-Routing (nginx/caddy) auf eine App
+4. App liest Subdomain (`abc123`) und lädt Profil aus DB
+
+### Warum nicht „eine Datei pro Profil“?
+- schwer zu verwalten bei vielen Usern
+- Updates/Deletes sind mühsam
+- Sicherheits- und Rechteprüfung fehlen
+- kein gutes Skalieren
+
+## Security-Hinweis
+Dieses Projekt bleibt ein clientseitiger Prototyp mit `localStorage`.
+Für ein sicheres Profilsystem brauchst du serverseitige Auth, DB, sichere Sessions (HttpOnly Cookies), Upload-Validierung und Rate-Limits.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,102 @@
+const APP = {
+  keys: {
+    session: "addictionranks.session",
+    users: "addictionranks.users",
+    entries: "addictionranks.entries",
+    forum: "addictionranks.forum.posts",
+  },
+  categories: {
+    leaderboard: ["Alkohol", "Rauchen", "Screentime", "Glücksspiel"],
+    forum: ["Off topic", "Videospiele", "Selbsthilfe", "Selbstzerstörung"],
+  },
+};
+
+const Storage = {
+  loadArray(key) {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(key) || "[]");
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  },
+  save(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+};
+
+function randomCode() {
+  return Math.random().toString(36).slice(2, 8).toUpperCase();
+}
+
+function profileUrl(code) {
+  return `profile.html?code=${encodeURIComponent(code)}`;
+}
+
+function placeholderSvg(label = "Kein Bild") {
+  return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='260'%3E%3Crect width='100%25' height='100%25' fill='%23090909'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%2333ff66' font-size='16'%3E${encodeURIComponent(label)}%3C/text%3E%3C/svg%3E`;
+}
+
+const Users = {
+  all() {
+    return Storage.loadArray(APP.keys.users);
+  },
+  byCode(code) {
+    return this.all().find((user) => user.code === code) || null;
+  },
+  saveAll(users) {
+    Storage.save(APP.keys.users, users);
+  },
+  upsert({ code, name, about = "", photo = "" }) {
+    const users = this.all();
+    const index = users.findIndex((u) => u.code === code);
+    const existing = index >= 0 ? users[index] : null;
+
+    const next = {
+      code,
+      name: name || existing?.name || "User",
+      about,
+      photo: photo || existing?.photo || "",
+    };
+
+    if (index >= 0) users[index] = next;
+    else users.push(next);
+    this.saveAll(users);
+    return next;
+  },
+};
+
+const Session = {
+  get() {
+    try {
+      return JSON.parse(localStorage.getItem(APP.keys.session) || "null");
+    } catch {
+      return null;
+    }
+  },
+  set(data) {
+    Storage.save(APP.keys.session, data);
+  },
+  clear() {
+    localStorage.removeItem(APP.keys.session);
+  },
+};
+
+function fillSelect(select, categories) {
+  select.innerHTML = '<option value="">Bitte wählen</option>';
+  categories.forEach((category) => {
+    const option = document.createElement("option");
+    option.value = category;
+    option.textContent = category;
+    select.appendChild(option);
+  });
+}
+
+function fileToDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}

--- a/forum.html
+++ b/forum.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AddictionRanks // Forum</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container terminal">
+      <header>
+        <h1>&gt; Forum</h1>
+        <p class="subtitle">Diskussion + Bilder</p>
+        <nav class="nav-links">
+          <a href="index.html">Leaderboard</a>
+          <a href="forum.html" aria-current="page">Forum</a>
+          <a href="profile.html">Profil</a>
+        </nav>
+      </header>
+
+      <section class="card">
+        <h2>Forum Login</h2>
+        <p id="forum-auth-state" class="hint"></p>
+        <form id="forum-login-form">
+          <label>Code <input id="forum-code" maxlength="8" required /></label>
+          <label>Name <input id="forum-name" maxlength="24" required /></label>
+          <button type="submit">Login</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Neuer Beitrag</h2>
+        <form id="forum-form">
+          <label>Kategorie <select id="forum-category" required></select></label>
+          <label>Titel <input id="forum-title" maxlength="70" required /></label>
+          <label>Text <textarea id="forum-body" rows="4" maxlength="500" required></textarea></label>
+          <label>Bild (optional) <input id="forum-image" type="file" accept="image/*" /></label>
+          <button type="submit">Posten</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Beiträge</h2>
+        <div id="forum-list" class="leaderboard"></div>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+    <script src="forum.js"></script>
+  </body>
+</html>

--- a/forum.js
+++ b/forum.js
@@ -1,0 +1,117 @@
+const forumList = document.querySelector("#forum-list");
+
+function posts() {
+  return Storage.loadArray(APP.keys.forum);
+}
+
+function savePosts(next) {
+  Storage.save(APP.keys.forum, next);
+}
+
+function renderAuthState() {
+  const session = Session.get();
+  const el = document.querySelector("#forum-auth-state");
+  el.textContent = session
+    ? `Eingeloggt als ${session.name} [${session.code}]`
+    : "Nicht eingeloggt";
+}
+
+function loginForum(event) {
+  event.preventDefault();
+  const code = document.querySelector("#forum-code").value.trim().toUpperCase();
+  const name = document.querySelector("#forum-name").value.trim();
+  if (!code || !name) return;
+
+  const existing = Users.byCode(code);
+  const user = Users.upsert({ code, name, about: existing?.about || "", photo: existing?.photo || "" });
+  Session.set({ code: user.code, name: user.name, about: user.about });
+  event.target.reset();
+  renderAuthState();
+}
+
+function avatarOf(code) {
+  return Users.byCode(code)?.photo || placeholderSvg("Profil");
+}
+
+function renderPosts() {
+  forumList.innerHTML = "";
+  const data = posts().sort((a, b) => b.createdAt - a.createdAt);
+  if (!data.length) {
+    forumList.innerHTML = '<p class="empty">Noch keine Posts.</p>';
+    return;
+  }
+
+  data.forEach((post) => {
+    const card = document.createElement("article");
+    card.className = "forum-post";
+
+    const header = document.createElement("div");
+    header.className = "author-row";
+    const avatar = document.createElement("img");
+    avatar.className = "mini-avatar";
+    avatar.src = avatarOf(post.authorCode);
+    avatar.alt = `Profilbild von ${post.authorName}`;
+
+    const authorLink = document.createElement("a");
+    authorLink.href = profileUrl(post.authorCode);
+    authorLink.textContent = post.authorName;
+
+    const meta = document.createElement("p");
+    meta.className = "hint";
+    meta.textContent = `in ${post.category}`;
+
+    header.append(avatar, authorLink);
+
+    const title = document.createElement("h3");
+    title.textContent = post.title;
+    const body = document.createElement("p");
+    body.textContent = post.body;
+
+    card.append(header, meta, title, body);
+
+    if (post.image) {
+      const img = document.createElement("img");
+      img.className = "forum-image";
+      img.src = post.image;
+      img.alt = `Bild zu ${post.title}`;
+      card.appendChild(img);
+    }
+
+    forumList.appendChild(card);
+  });
+}
+
+document.querySelector("#forum-login-form").addEventListener("submit", loginForum);
+
+document.querySelector("#forum-form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const session = Session.get();
+  if (!session) return alert("Bitte zuerst einloggen.");
+
+  const category = document.querySelector("#forum-category").value;
+  const title = document.querySelector("#forum-title").value.trim();
+  const body = document.querySelector("#forum-body").value.trim();
+  const file = document.querySelector("#forum-image").files[0];
+  if (!category || !title || !body) return;
+
+  const image = file ? await fileToDataUrl(file) : "";
+  const next = posts();
+  next.push({
+    id: crypto.randomUUID(),
+    category,
+    title,
+    body,
+    image,
+    authorCode: session.code,
+    authorName: session.name,
+    createdAt: Date.now(),
+  });
+
+  savePosts(next);
+  event.target.reset();
+  renderPosts();
+});
+
+fillSelect(document.querySelector("#forum-category"), APP.categories.forum);
+renderAuthState();
+renderPosts();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AddictionRanks // Leaderboard</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container terminal">
+      <header>
+        <h1>&gt; AddictionRanks</h1>
+        <p class="subtitle">Leaderboard-Konsole (lokal gespeichert)</p>
+        <nav class="nav-links">
+          <a href="index.html" aria-current="page">Leaderboard</a>
+          <a href="forum.html">Forum</a>
+          <a href="profile.html">Profil</a>
+        </nav>
+      </header>
+
+      <section class="card">
+        <h2>Login</h2>
+        <p class="hint">Nur Code + Name. Einfach halten.</p>
+        <div id="auth-out">
+          <button type="button" id="generate-code">Code generieren</button>
+          <p id="generated-code" class="mono"></p>
+          <form id="login-form">
+            <label>Code <input id="login-code" maxlength="8" required /></label>
+            <label>Name <input id="login-name" maxlength="24" required /></label>
+            <label>Über dich <input id="login-about" maxlength="80" /></label>
+            <button type="submit">Login / Account</button>
+          </form>
+        </div>
+        <div id="auth-in" hidden>
+          <p id="session-line"></p>
+          <p><a id="session-profile-link" href="profile.html">Zu meinem Profil</a></p>
+          <button type="button" id="logout">Logout</button>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Post hinzufügen</h2>
+        <form id="entry-form">
+          <label>Post-Name <input id="post-name" maxlength="24" required /></label>
+          <label>Kategorie <select id="entry-category" required></select></label>
+          <label>Bild <input id="entry-photo" type="file" accept="image/*" required /></label>
+          <button type="submit">Post speichern</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Leaderboards</h2>
+        <p class="hint">Ein User kann pro Bild nur einmal voten.</p>
+        <div id="boards" class="leaderboards"></div>
+      </section>
+    </main>
+
+    <template id="entry-template">
+      <article class="entry">
+        <img class="entry-photo" alt="User Upload" />
+        <div class="entry-content">
+          <h3 class="entry-title"></h3>
+          <p class="entry-owner"></p>
+          <p class="entry-score"></p>
+          <div class="entry-actions">
+            <button class="vote-up" type="button">+1</button>
+            <button class="vote-down" type="button">-1</button>
+          </div>
+          <p class="vote-info hint"></p>
+        </div>
+      </article>
+    </template>
+
+    <script src="app.js"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AddictionRanks // Profil</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container terminal">
+      <header>
+        <h1>&gt; Profil</h1>
+        <p class="subtitle">Öffentliches Profil + eigenes Edit</p>
+        <nav class="nav-links">
+          <a href="index.html">Leaderboard</a>
+          <a href="forum.html">Forum</a>
+          <a href="profile.html" aria-current="page">Profil</a>
+        </nav>
+      </header>
+
+      <section class="card">
+        <h2>Profil ansehen</h2>
+        <p class="hint">URL: <span class="mono">profile.html?code=DEINCODE</span></p>
+        <div id="profile-view"></div>
+      </section>
+
+      <section class="card">
+        <h2>Alle Profile</h2>
+        <div id="profiles-grid" class="profiles-grid"></div>
+      </section>
+
+      <section class="card">
+        <h2>Eigenes Profil bearbeiten</h2>
+        <p id="edit-hint" class="hint"></p>
+        <form id="profile-form">
+          <label>Name <input id="edit-name" maxlength="24" required /></label>
+          <label>Über dich <input id="edit-about" maxlength="80" /></label>
+          <label>Neues Profilbild <input id="edit-photo" type="file" accept="image/*" /></label>
+          <button type="submit">Speichern</button>
+        </form>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+    <script src="profile.js"></script>
+  </body>
+</html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,88 @@
+const profileView = document.querySelector("#profile-view");
+const profilesGrid = document.querySelector("#profiles-grid");
+const editHint = document.querySelector("#edit-hint");
+const profileForm = document.querySelector("#profile-form");
+
+function viewedCode() {
+  const urlCode = new URLSearchParams(window.location.search).get("code");
+  const session = Session.get();
+  return urlCode || session?.code || "";
+}
+
+function renderProfilesGrid() {
+  const users = Users.all();
+  profilesGrid.innerHTML = "";
+  if (!users.length) {
+    profilesGrid.innerHTML = '<p class="empty">Noch keine Profile vorhanden.</p>';
+    return;
+  }
+
+  users.forEach((user) => {
+    const card = document.createElement("a");
+    card.className = "mini-profile";
+    card.href = profileUrl(user.code);
+    card.innerHTML = `
+      <img class="mini-avatar large" src="${user.photo || placeholderSvg("Profil")}" alt="Profilbild von ${user.name}" />
+      <span>${user.name}</span>
+    `;
+    profilesGrid.appendChild(card);
+  });
+}
+
+function renderProfile() {
+  const code = viewedCode();
+  const user = Users.byCode(code);
+  const session = Session.get();
+  const own = Boolean(user && session && session.code === user.code);
+
+  if (!user) {
+    profileView.innerHTML = '<p class="empty">Profil nicht gefunden.</p>';
+    editHint.textContent = "Kein Profil geladen.";
+    [...profileForm.elements].forEach((el) => (el.disabled = true));
+    return;
+  }
+
+  profileView.innerHTML = `
+    <article class="profile-card">
+      <img class="profile-photo" src="${user.photo || placeholderSvg("Profil")}" alt="Profilbild von ${user.name}" />
+      <h3>${user.name}</h3>
+      <p class="mono">Code: ${user.code}</p>
+      <p>${user.about || "Kein Text gesetzt."}</p>
+      <p class="hint">Pseudo-Subdomain lokal: /u/${user.code} (in echt per Server-Routing)</p>
+    </article>
+  `;
+
+  [...profileForm.elements].forEach((el) => (el.disabled = !own));
+  if (!own) {
+    editHint.textContent = "Nur im eigenen Profil editierbar.";
+    return;
+  }
+
+  editHint.textContent = "Du bearbeitest dein eigenes Profil.";
+  document.querySelector("#edit-name").value = user.name;
+  document.querySelector("#edit-about").value = user.about || "";
+}
+
+profileForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const session = Session.get();
+  const code = viewedCode();
+  if (!session || session.code !== code) return alert("Nur eigenes Profil editierbar.");
+
+  const existing = Users.byCode(code);
+  if (!existing) return;
+
+  const name = document.querySelector("#edit-name").value.trim();
+  const about = document.querySelector("#edit-about").value.trim();
+  const file = document.querySelector("#edit-photo").files[0];
+  const photo = file ? await fileToDataUrl(file) : existing.photo;
+
+  const user = Users.upsert({ code, name: name || existing.name, about, photo });
+  Session.set({ code: user.code, name: user.name, about: user.about });
+  event.target.reset();
+  renderProfile();
+  renderProfilesGrid();
+});
+
+renderProfile();
+renderProfilesGrid();

--- a/script.js
+++ b/script.js
@@ -1,0 +1,196 @@
+const entryTemplate = document.querySelector("#entry-template");
+const boards = document.querySelector("#boards");
+
+const authOut = document.querySelector("#auth-out");
+const authIn = document.querySelector("#auth-in");
+const loginForm = document.querySelector("#login-form");
+
+function entries() {
+  return Storage.loadArray(APP.keys.entries);
+}
+
+function saveEntries(next) {
+  Storage.save(APP.keys.entries, next);
+}
+
+function score(entry) {
+  return Object.values(entry.votes || {}).reduce((sum, value) => sum + Number(value || 0), 0);
+}
+
+function userCanVote(entry, code) {
+  return code && entry.votes?.[code] === undefined;
+}
+
+function loginWithForm(event) {
+  event.preventDefault();
+  const code = document.querySelector("#login-code").value.trim().toUpperCase();
+  const name = document.querySelector("#login-name").value.trim();
+  const about = document.querySelector("#login-about").value.trim();
+  if (!code || !name) return;
+
+  const user = Users.upsert({ code, name, about });
+  Session.set({ code: user.code, name: user.name, about: user.about });
+  loginForm.reset();
+  renderAuth();
+  renderBoards();
+}
+
+function renderAuth() {
+  const session = Session.get();
+  if (!session) {
+    authOut.hidden = false;
+    authIn.hidden = true;
+    return;
+  }
+
+  authOut.hidden = true;
+  authIn.hidden = false;
+  document.querySelector("#session-line").textContent = `${session.name} [${session.code}] ${session.about ? "- " + session.about : ""}`;
+  document.querySelector("#session-profile-link").href = profileUrl(session.code);
+}
+
+function castVote(entryId, value) {
+  const session = Session.get();
+  if (!session) return alert("Bitte einloggen.");
+
+  const next = entries().map((entry) => {
+    if (entry.id !== entryId) return entry;
+    if (!userCanVote(entry, session.code)) return entry;
+    return { ...entry, votes: { ...(entry.votes || {}), [session.code]: value } };
+  });
+
+  saveEntries(next);
+  renderBoards();
+}
+
+function avatarOf(code) {
+  return Users.byCode(code)?.photo || placeholderSvg("Profil");
+}
+
+function buildEntry(entry) {
+  const node = entryTemplate.content.firstElementChild.cloneNode(true);
+  const session = Session.get();
+
+  node.querySelector(".entry-photo").src = entry.photo;
+  node.querySelector(".entry-title").textContent = `${entry.title} (${entry.category})`;
+
+  const owner = node.querySelector(".entry-owner");
+  owner.innerHTML = "";
+  const avatar = document.createElement("img");
+  avatar.className = "mini-avatar";
+  avatar.src = avatarOf(entry.ownerCode);
+  avatar.alt = `Profilbild von ${entry.ownerName}`;
+  const link = document.createElement("a");
+  link.href = profileUrl(entry.ownerCode);
+  link.textContent = entry.ownerName;
+  owner.append("von ", avatar, " ", link);
+
+  node.querySelector(".entry-score").textContent = `Score: ${score(entry)}`;
+  node.querySelector(".vote-info").textContent = userCanVote(entry, session?.code)
+    ? "Noch nicht gevotet"
+    : "Vote schon gesetzt";
+
+  node.querySelector(".vote-up").addEventListener("click", () => castVote(entry.id, 1));
+  node.querySelector(".vote-down").addEventListener("click", () => castVote(entry.id, -1));
+  return node;
+}
+
+function renderCategory(category) {
+  const wrap = document.createElement("section");
+  wrap.className = "category-block";
+  const data = entries()
+    .filter((entry) => entry.category === category)
+    .sort((a, b) => score(b) - score(a));
+
+  wrap.innerHTML = `<h3>${category}</h3><h4>Foto-Leaderboard</h4>`;
+  const photoList = document.createElement("div");
+  photoList.className = "leaderboard";
+
+  if (!data.length) {
+    photoList.innerHTML = '<p class="empty">Keine Einträge</p>';
+  } else {
+    data.forEach((entry) => photoList.appendChild(buildEntry(entry)));
+  }
+  wrap.appendChild(photoList);
+
+  const usersMap = new Map();
+  data.forEach((entry) => {
+    const row = usersMap.get(entry.ownerCode) || { code: entry.ownerCode, name: entry.ownerName, score: 0, posts: 0 };
+    row.score += score(entry);
+    row.posts += 1;
+    usersMap.set(entry.ownerCode, row);
+  });
+
+  const userBox = document.createElement("div");
+  userBox.className = "simple-list";
+  wrap.appendChild(Object.assign(document.createElement("h4"), { textContent: "User-Leaderboard" }));
+
+  const rows = [...usersMap.values()].sort((a, b) => b.score - a.score);
+  if (!rows.length) userBox.innerHTML = '<p class="empty">Keine User</p>';
+  rows.forEach((row, idx) => {
+    const p = document.createElement("p");
+    const avatar = document.createElement("img");
+    avatar.className = "mini-avatar";
+    avatar.src = avatarOf(row.code);
+    avatar.alt = `Profilbild von ${row.name}`;
+    const link = document.createElement("a");
+    link.href = profileUrl(row.code);
+    link.textContent = row.name;
+    p.append(`${idx + 1}. `, avatar, " ");
+    p.appendChild(link);
+    p.append(` - Score ${row.score}, Posts ${row.posts}`);
+    userBox.appendChild(p);
+  });
+  wrap.appendChild(userBox);
+  return wrap;
+}
+
+function renderBoards() {
+  boards.innerHTML = "";
+  APP.categories.leaderboard.forEach((category) => boards.appendChild(renderCategory(category)));
+}
+
+document.querySelector("#generate-code").addEventListener("click", () => {
+  const code = randomCode();
+  document.querySelector("#generated-code").textContent = `Code: ${code}`;
+  document.querySelector("#login-code").value = code;
+});
+
+document.querySelector("#logout").addEventListener("click", () => {
+  Session.clear();
+  renderAuth();
+  renderBoards();
+});
+
+loginForm.addEventListener("submit", loginWithForm);
+
+document.querySelector("#entry-form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const session = Session.get();
+  if (!session) return alert("Bitte einloggen.");
+
+  const title = document.querySelector("#post-name").value.trim();
+  const category = document.querySelector("#entry-category").value;
+  const file = document.querySelector("#entry-photo").files[0];
+  if (!title || !category || !file) return;
+
+  const photo = await fileToDataUrl(file);
+  const next = entries();
+  next.push({
+    id: crypto.randomUUID(),
+    title,
+    category,
+    photo,
+    ownerCode: session.code,
+    ownerName: session.name,
+    votes: {},
+  });
+
+  saveEntries(next);
+  event.target.reset();
+  renderBoards();
+});
+
+fillSelect(document.querySelector("#entry-category"), APP.categories.leaderboard);
+renderAuth();
+renderBoards();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,140 @@
+:root {
+  --bg: #050505;
+  --line: #1f7a3f;
+  --text: #33ff66;
+  --muted: #77c98f;
+  font-family: "Courier New", Consolas, monospace;
+  color-scheme: dark;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #101010 0, var(--bg) 60%);
+  color: var(--text);
+}
+
+.container { max-width: 980px; margin: 0 auto; padding: 1rem; }
+.terminal { text-shadow: 0 0 4px rgba(51, 255, 102, 0.15); }
+header { text-align: center; margin-bottom: 1rem; }
+.subtitle, .hint { color: var(--muted); }
+.mono { font-family: inherit; letter-spacing: 0.04em; }
+
+.nav-links { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; }
+.nav-links a {
+  color: var(--text);
+  text-decoration: none;
+  border: 1px solid var(--line);
+  padding: 0.35rem 0.75rem;
+  border-radius: 6px;
+  background: #0b120d;
+}
+.nav-links a[aria-current="page"] { background: #10361e; }
+
+.card {
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, #0d0d0d, #090909);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+form { display: grid; gap: 0.65rem; }
+label { display: grid; gap: 0.25rem; font-size: 0.95rem; }
+
+input, select, button, textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  background: #051208;
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0.55rem;
+  font: inherit;
+}
+
+textarea { resize: vertical; }
+button { cursor: pointer; }
+button:hover { background: #10361e; }
+a { color: #89ffae; }
+
+.leaderboards, .leaderboard { display: grid; gap: 0.75rem; }
+.category-block { border-top: 1px dashed var(--line); padding-top: 0.6rem; }
+
+.entry {
+  border: 1px solid var(--line);
+  background: #081009;
+  border-radius: 8px;
+  padding: 0.7rem;
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 0.75rem;
+}
+
+.entry-photo, .forum-image, .profile-photo {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  object-fit: cover;
+  background: #041006;
+}
+
+.entry-photo { height: 130px; }
+.forum-image { max-height: 320px; margin-top: 0.5rem; }
+.profile-photo { width: 180px; height: 180px; }
+
+.mini-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  object-fit: cover;
+  vertical-align: middle;
+}
+
+.mini-avatar.large {
+  width: 72px;
+  height: 72px;
+  border-radius: 8px;
+}
+
+.entry-content h3, .entry-content p, .forum-post h3, .forum-post p, .profile-card h3, .profile-card p { margin: 0 0 0.4rem; }
+.entry-actions { display: flex; gap: 0.4rem; }
+.simple-list p, .empty { color: var(--muted); margin: 0.2rem 0; }
+
+.author-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.3rem;
+}
+
+.forum-post, .profile-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #071108;
+  padding: 0.7rem;
+}
+
+.profiles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 0.6rem;
+}
+
+.mini-profile {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #071108;
+  padding: 0.5rem;
+  text-decoration: none;
+  color: var(--text);
+  display: grid;
+  justify-items: center;
+  gap: 0.4rem;
+}
+
+@media (max-width: 680px) {
+  .entry { grid-template-columns: 1fr; }
+  .entry-photo { height: 220px; }
+}


### PR DESCRIPTION
### Motivation
- Provide a small terminal-style web app prototype for local leaderboards, a forum and public profiles using only client-side storage.
- Keep authentication intentionally minimal (code + name) so users can create and edit profiles locally without a backend.
- Enable image uploads, voting and per-category leaderboards while documenting security limitations in the README.

### Description
- Add core utilities and in-browser storage/session helpers in `app.js`, including `Storage`, `Users`, `Session`, `fileToDataUrl` and category config.
- Implement main pages and UI: `index.html` (leaderboards + posting), `forum.html` (threads + image posts), and `profile.html` (view/edit profiles), together with `script.js`, `forum.js`, and `profile.js` for page logic and interactions.
- Implement client-side features such as image uploads stored as data URLs, one vote per user per image, profile editing tied to session code, and `profile.html?code=...` linking via `profileUrl` helper.
- Add `styles.css` providing the "schwarzes UI + grüne Schrift" terminal theme and update `README.md` with usage, categories and security notes.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac75002a90832a884858e68157a513)